### PR TITLE
Add Docker and renv bootstrap setup

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,3 @@
+if (file.exists("renv/activate.R")) {
+  source("renv/activate.R")
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "vg_ad",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspace/vg_ad",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "REditorSupport.r",
+        "RDebugger.r-debugger"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: "4.4.1"
+      - name: Install dependencies
+        run: Rscript scripts/setup_env.R
+      - name: Run dryrun
+        run: Rscript scripts/run_dryrun.R --sensor_id VG09 --date 2023-01-01

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ logs/*
 !logs/.gitkeep
 out/*
 !out/.gitkeep
+renv/library
+.Rhistory
+.Rproj.user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rocker/verse:4.4.1
+
+WORKDIR /workspace/vg_ad
+
+COPY . /workspace/vg_ad
+
+RUN Rscript scripts/setup_env.R
+
+CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: docker-build docker-shell docker-dryrun setup dryrun
+
+docker-build:
+	docker build -t vg_ad .
+
+docker-shell:
+	docker run --rm -it -v $(PWD):/workspace/vg_ad vg_ad bash
+
+docker-dryrun:
+	docker run --rm -v $(PWD):/workspace/vg_ad vg_ad Rscript scripts/run_dryrun.R --sensor_id VG09 --date 2023-01-01
+
+setup:
+	Rscript scripts/setup_env.R
+
+dryrun:
+	Rscript scripts/run_dryrun.R --sensor_id VG09 --date 2023-01-01

--- a/scripts/setup_env.R
+++ b/scripts/setup_env.R
@@ -1,0 +1,24 @@
+#!/usr/bin/env Rscript
+
+if (!requireNamespace("renv", quietly = TRUE)) {
+  install.packages("renv", repos = "https://cloud.r-project.org")
+}
+
+if (!file.exists("renv.lock")) {
+  renv::init(bare = TRUE, quiet = TRUE)
+  pkgs <- c(
+    "tidyverse",
+    "lubridate",
+    "zoo",
+    "yaml",
+    "refund",
+    "fdapace",
+    "roahd",
+    "fdaoutlier",
+    "future.apply"
+  )
+  install.packages(pkgs, repos = "https://cloud.r-project.org")
+  renv::snapshot(prompt = FALSE)
+} else {
+  renv::restore(prompt = FALSE)
+}


### PR DESCRIPTION
## Summary
- Add Dockerfile and Makefile for containerized runs and dryrun script
- Bootstrap renv packages via setup_env.R and auto-activate with .Rprofile
- Provide VS Code devcontainer and CI workflow

## Testing
- `make setup` *(fails: Rscript: No such file or directory)*
- `make dryrun` *(fails: Rscript: No such file or directory)*
- `make docker-dryrun` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aabd253a2c833299621dea5ce48478