### PR TITLE
Use setup-renv in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,28 @@
 name: CI
-
 on:
   push:
     branches: [ main ]
   pull_request:
-
 jobs:
-  build:
+  dryrun:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.4.1"
-      - name: Install dependencies
-        run: Rscript scripts/setup_env.R
-      - name: Run dryrun
-        run: Rscript scripts/run_dryrun.R --sensor_id VG09 --date 2023-01-01
+          r-version: '4.4.1'
+          use-public-rspm: true
+
+      # Restore packages via renv with caching
+      - name: Set up renv
+        uses: r-lib/actions/setup-renv@v2
+        with:
+          cache-version: 1
+
+      # Run the dry run script (no setup_env.R here)
+      - name: Dry run
+        run: Rscript scripts/run_dryrun.R --sensor_id VG09 --date 2025-08-10
+
+      - name: sessionInfo
+        run: Rscript -e 'sessionInfo()'

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -3,24 +3,35 @@ on:
   push:
     branches: [ "main" ]
 jobs:
-  pkgdown:
+  build-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+
       - uses: r-lib/actions/setup-r@v2
-        with: { use-public-rspm: true }
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: |
-            any::pkgdown
-            any::devtools
-            any::quarto
-          needs: website
-      - name: Build site
+          r-version: '4.4.1'
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      # Restore packages via renv with caching
+      - name: Set up renv
+        uses: r-lib/actions/setup-renv@v2
+        with:
+          cache-version: 1
+
+      # Build site into ./docs
+      - name: Build pkgdown site
         run: |
           R -q -e 'devtools::document()'
           R -q -e 'pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)'
+
+      # Deploy (docs/ branch publishing)
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/main'

--- a/renv.lock
+++ b/renv.lock
@@ -1,0 +1,19 @@
+{
+  "R": {
+    "Version": "4.4.1",
+    "Repositories": [
+      { "Name": "CRAN", "URL": "https://cloud.r-project.org" }
+    ]
+  },
+  "Packages": {
+    "dplyr": { "Package": "dplyr", "Version": "1.1.4", "Source": "CRAN" },
+    "readr": { "Package": "readr", "Version": "2.1.5", "Source": "CRAN" },
+    "tibble": { "Package": "tibble", "Version": "3.2.1", "Source": "CRAN" },
+    "lubridate": { "Package": "lubridate", "Version": "1.9.3", "Source": "CRAN" },
+    "yaml": { "Package": "yaml", "Version": "2.3.7", "Source": "CRAN" },
+    "refund": { "Package": "refund", "Version": "0.1-28", "Source": "CRAN" },
+    "pkgdown": { "Package": "pkgdown", "Version": "2.0.7", "Source": "CRAN" },
+    "devtools": { "Package": "devtools", "Version": "2.4.5", "Source": "CRAN" },
+    "quarto": { "Package": "quarto", "Version": "1.4.0", "Source": "CRAN" }
+  }
+}


### PR DESCRIPTION
## Summary
- Switch CI to r-lib/actions/setup-renv with caching on R 4.4.1.
- Build and deploy pkgdown site via setup-renv.
- Add `renv.lock` to allow package restoration.

## Testing
- `Rscript scripts/run_dryrun.R --sensor_id VG09 --date 2025-08-10` *(fails: there is no package called ‘dplyr’)*
- `Rscript -e 'sessionInfo()'`


------
https://chatgpt.com/codex/tasks/task_e_68aac369b1c48332a13901ac9761f417